### PR TITLE
Fixed some compiler errors

### DIFF
--- a/websocket/conn.go
+++ b/websocket/conn.go
@@ -109,7 +109,7 @@ func (c *Conn) IsClosed() bool {
 // Close closes websocket connection and updates channel.
 func (c *Conn) Close() (err error) {
 	if c.c != nil {
-		err = c.c.Close("Bye")
+		err = c.c.Close()
 		if err == nil {
 			c.c = nil
 		}
@@ -151,7 +151,7 @@ func (c *Conn) Send(tp Type, tc Topic, sym string) (r Response, err error) {
 	var data []byte
 	data, err = json.Marshal(req)
 	if err != nil {
-		c.c.Close("error marshaling data")
+		c.c.Close()
 		return
 	}
 	_, err = c.c.Write(data)

--- a/websocket/websocket.go
+++ b/websocket/websocket.go
@@ -97,7 +97,7 @@ func (ws *WebSocket) Subscribe(tc Topic, sym string) (c *Conn, err error) {
 			c.init()
 			go c.handle()
 		} else {
-			conn.Close(err.Error())
+			conn.Close()
 			c = nil
 		}
 	}


### PR DESCRIPTION
This can be squashed safely 
Due to errors in golang-crypto-trading-bot build from travis due to newer version of fastws
```
# github.com/fiore/kucoin-go/websocket
../../fiore/kucoin-go/websocket/conn.go:112:18: too many arguments in call to c.c.Close
	have (string)
	want ()
../../fiore/kucoin-go/websocket/conn.go:154:12: too many arguments in call to c.c.Close
	have (string)
	want ()
../../fiore/kucoin-go/websocket/websocket.go:100:14: too many arguments in call to conn.Close
	have (string)
	want ()
The command "go get -t ./..." failed and exited with 2 during .
```
removed string message from Close function